### PR TITLE
Added example of diagrams with markdeep

### DIFF
--- a/diagrams_with_markdeep.md.html
+++ b/diagrams_with_markdeep.md.html
@@ -1,0 +1,18 @@
+
+*******************************************
+* Length: 2        +-------->  299_792_458
+* Capacity: 2      |                25_813
+* Data: -----------+
+*******************************************
+
+*******************************************
+* Length: 3        +---//--->  299_792_458
+* Capacity: 4      |                25_813
+* Data: -----------+
+*                 |
+*                 +-------->  299_792_458
+*                                   25_813
+*                                     137
+*******************************************
+
+<!-- Markdeep: --><style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style><script src="markdeep.min.js" charset="utf-8"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js" charset="utf-8"></script><script>window.alreadyProcessedMarkdeep||(document.body.style.visibility="visible")</script>


### PR DESCRIPTION
being a nim forum and irc lurker, yesterday I saw this: https://irclogs.nim-lang.org/27-01-2020.html#08:40:12
and the next day I ran into this: https://casual-effects.com/markdeep/
and it was very quick to take the diagrams, wrap them in asterisks and add markdeep line.

The resulting file, when opened in the browser looks like this:

![image](https://user-images.githubusercontent.com/4997234/73249072-7751f500-41b4-11ea-8528-875dad88f1ed.png)

Maybe it can be helpful, if you think so, I can try to make it work through the rst2html. Have a good day!